### PR TITLE
Fixing gateway does not send all retained messages

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -62,5 +62,5 @@ build_script:
 
 test_script:
     - echo ------------------------- Testing -------------------------
-    - ctest 
+    - ctest -V
 

--- a/gateway/src/lib/session_op/PubSend.cpp
+++ b/gateway/src/lib/session_op/PubSend.cpp
@@ -249,6 +249,7 @@ void PubSend::doSend()
 
     if (m_currPub->m_qos == QoS_AtMostOnceDelivery) {
         m_currPub.reset();
+        checkSend();
         return;
     }
 


### PR DESCRIPTION
If a client subscribes topics that are retained, the gateway did not forward all messages at once if they used QoS=0.


I created the PR and hope that the pipeline runs the tests, unfortunately I can't run them currently.

Fixes https://github.com/commschamp/cc.mqttsn.libs/issues/12